### PR TITLE
planar links can now simply use the previoud chain's output var name,…

### DIFF
--- a/chainfactory/core/factory.py
+++ b/chainfactory/core/factory.py
@@ -232,7 +232,9 @@ class ChainFactoryLink:
                     ) as file:
                         file_content = file.read()
 
-                        print(f"[{name}]" "Generating mask template for:", variables)
+                        print(
+                            f"[{name}]", "Generating new mask template for:", variables
+                        )
 
                         engine = internal_engine_cls.from_str(
                             file_content, config=internal_engine_config
@@ -451,7 +453,11 @@ class ChainFactory:
                             if var.startswith(previous_link._name):
                                 continue
 
-                            full_var = f"{previous_link._name}$element${var}"
+                            if var.startswith("element"):
+                                full_var = f"{previous_link._name}${var}"
+                            else:
+                                full_var = f"{previous_link._name}$element${var}"
+
                             updated_input_variables.append(full_var)
                             link.prompt.template = link.prompt.template.replace(
                                 "{" + var + "}",

--- a/examples/haiku_generate_review_validate.fctr
+++ b/examples/haiku_generate_review_validate.fctr
@@ -1,4 +1,4 @@
-@chainlink haiku-generator
+@chainlink
 prompt: Write {num} haiku(s) about {topic}. Use the standard 5-7-5 syllable pattern.
 def:
   Haiku:
@@ -8,7 +8,7 @@ out:
 	topic: str % the original topic. required.
   haikus : list[Haiku]
 
-@chainlink haiku-critic ||
+@chainlink ||
 purpose: critical analysis of a haiku in 3 to 5 sentences
 in:
 	topic: str
@@ -18,11 +18,11 @@ out:
 	review: str % concise literary analysis of this haiku.
 	haiku: str % original haiku text. required.
 
-@chainlink validator ||
+@chainlink ||
 purpose: validate if critical review of a haiku is sensible
 in:
-	haiku-critic.element.haiku: str % the haiku text
-	haiku-critic.element.review: str % ai generated review of the haiku
+	haiku: str
+	review: str
 out:
 	valid: bool % true if the review is sensible, false otherwise. required.
 	haiku: str % verbatim haiku text. required.

--- a/mock.py
+++ b/mock.py
@@ -100,50 +100,7 @@ def haiku_generate_review_validate(topic="Python", num=2):
         "examples/haiku_generate_review_validate.fctr"
     )
 
-    res = haiku_review_engine(topic=topic, num=1)
-
-    for item in res:
-        print("==================")
-        print("Haiku:")
-        print(item.haiku)
-        print("\n")
-        print("Review:")
-        print(item.review)
-        print("\n")
-        print("Validation:", item.valid)
-        print("Reason:", item.reasoning)
-        print("==================\n\n\n")
-
-
-def haiku_generate_review_validate(topic="Python", num=2):
-    """
-    Demonstrates how to create a chain with 3 steps and these types of links:
-
-    <input>           ------------------------- the initial values. (topic, num in this case)
-      |
-    [haiku-generator] ------------------------- (generate `num` haiku in 1 inference)
-      |
-    (split)           ------------------------- output split into `num` inputs for next step. sequential -> parallel linking.
-      |
-    [haiku-critic]    ------------------------- parallel (`num` inferences simultaneously in threadpool)
-      |
-    (map)             ------------------------- output elements mapped into inputs for next step. parallel -> parallel linking.
-      |
-    [validator]       ------------------------- parallel (`num` inferences simultaneously in threadpool)
-      |
-    <output>          ------------------------- the output is a list of validator.out model instances
-
-    Note: Mapping is a slightly complex form of filtering. It is applied on all elements of previous chain's output at once.
-
-    Args:
-        topic (str, optional): The topic of the haiku. Defaults to "Python".
-        num (int, optional): The number of haikus to generate. Defaults to 2.
-    """
-    haiku_review_engine = Engine.from_file(
-        "examples/haiku_generate_review_validate.fctr"
-    )
-
-    res = haiku_review_engine(topic=topic, num=1)
+    res = haiku_review_engine(topic=topic, num=num)
 
     for item in res:
         print("==================")
@@ -197,13 +154,4 @@ def haiku_generate_review_validate_summary(topic="Python", num=2):
 
 
 if __name__ == "__main__":
-    config = ChainFactoryEngineConfig(
-        temperature=0.5,
-        print_trace=True,
-        print_trace_for_single_chain=True,
-    )
-    engine = Engine.from_file(
-        "examples/random_haiku.fctr", config=config, internal_engine_config=config
-    )
-
-    res = engine(num=5)
+    haiku_generate_review_validate()


### PR DESCRIPTION
… instead of the full field address


resolves #12 